### PR TITLE
Move network communication to its own class

### DIFF
--- a/src/main/java/io/relution/jenkins/scmsqs/factories/SQSFactoryImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/factories/SQSFactoryImpl.java
@@ -37,6 +37,8 @@ import io.relution.jenkins.scmsqs.interfaces.ExecutorHolder;
 import io.relution.jenkins.scmsqs.interfaces.SQSFactory;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueue;
 import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitor;
+import io.relution.jenkins.scmsqs.net.SQSChannel;
+import io.relution.jenkins.scmsqs.net.SQSChannelImpl;
 import io.relution.jenkins.scmsqs.threading.SQSQueueMonitorImpl;
 
 
@@ -85,7 +87,8 @@ public class SQSFactoryImpl implements SQSFactory {
 
     @Override
     public SQSQueueMonitor createMonitor(final ExecutorService executor, final SQSQueue queue) {
-        return new SQSQueueMonitorImpl(executor, this, queue);
+        final SQSChannel channel = this.createChannel(queue);
+        return new SQSQueueMonitorImpl(executor, channel);
     }
 
     @Override

--- a/src/main/java/io/relution/jenkins/scmsqs/factories/SQSFactoryImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/factories/SQSFactoryImpl.java
@@ -78,6 +78,12 @@ public class SQSFactoryImpl implements SQSFactory {
     }
 
     @Override
+    public SQSChannel createChannel(final SQSQueue queue) {
+        final AmazonSQS sqs = this.createSQS(queue);
+        return new SQSChannelImpl(sqs, queue, this);
+    }
+
+    @Override
     public SQSQueueMonitor createMonitor(final ExecutorService executor, final SQSQueue queue) {
         return new SQSQueueMonitorImpl(executor, this, queue);
     }

--- a/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSFactory.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/interfaces/SQSFactory.java
@@ -25,6 +25,8 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import io.relution.jenkins.scmsqs.net.SQSChannel;
+
 
 /**
  * Interface definition for factories that can create {@link SQSQueueMonitor} instances and related
@@ -48,6 +50,13 @@ public interface SQSFactory {
      * to the specified queue.
      */
     AmazonSQSAsync createSQSAsync(final SQSQueue queue);
+
+    /**
+     * Returns a new channel instance that can be used to communicate with the specified queue.
+     * @param queue The {@link SQSQueue} for which to create the channel.
+     * @return A new {@link SQSChannel} for the specified queue.
+     */
+    SQSChannel createChannel(final SQSQueue queue);
 
     /**
      * Returns a new monitor instance that can be used to poll the specified queue for new

--- a/src/main/java/io/relution/jenkins/scmsqs/net/SQSChannel.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/net/SQSChannel.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.relution.jenkins.scmsqs.net;
+
+import com.amazonaws.services.sqs.model.Message;
+
+import java.util.List;
+
+
+public interface SQSChannel {
+
+    List<Message> getMessages();
+
+    void deleteMessages(List<Message> messages);
+
+    String getQueueUuid();
+}

--- a/src/main/java/io/relution/jenkins/scmsqs/net/SQSChannelImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/net/SQSChannelImpl.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.relution.jenkins.scmsqs.net;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchResult;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.relution.jenkins.scmsqs.interfaces.SQSFactory;
+import io.relution.jenkins.scmsqs.interfaces.SQSQueue;
+import io.relution.jenkins.scmsqs.logging.Log;
+import io.relution.jenkins.scmsqs.util.ThrowIf;
+
+
+public class SQSChannelImpl implements SQSChannel {
+
+    private final AmazonSQS  sqs;
+    private final SQSQueue   queue;
+    private final SQSFactory factory;
+
+    private int              requestCount;
+
+    public SQSChannelImpl(final AmazonSQS sqs, final SQSQueue queue, final SQSFactory factory) {
+        ThrowIf.isNull(sqs, "sqs");
+        ThrowIf.isNull(queue, "queue");
+        ThrowIf.isNull(factory, "factory");
+
+        this.sqs = sqs;
+        this.queue = queue;
+        this.factory = factory;
+    }
+
+    @Override
+    public List<Message> getMessages() {
+        try {
+            this.requestCount++;
+            Log.fine("Send receive message request #%d for %s", this.requestCount, this.queue);
+
+            final ReceiveMessageRequest request = this.factory.createReceiveMessageRequest(this.queue);
+            final ReceiveMessageResult result = this.sqs.receiveMessage(request);
+
+            if (result == null) {
+                return Collections.emptyList();
+            }
+
+            return result.getMessages();
+
+        } catch (final com.amazonaws.AmazonServiceException e) {
+            Log.severe(e, "Failed to send receive message request for %s", this.queue);
+
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void deleteMessages(final List<Message> messages) {
+        if (messages == null || messages.size() == 0) {
+            return;
+        }
+
+        final DeleteMessageBatchResult result = this.deleteMessageBatch(messages);
+
+        if (result == null) {
+            return;
+        }
+
+        final List<?> failed = result.getFailed();
+        final List<?> success = result.getSuccessful();
+        Log.info("Deleted %d message(s) (%d failed) from %s", success.size(), failed.size(), this.queue);
+    }
+
+    @Override
+    public String getQueueUuid() {
+        return this.queue.getUuid();
+    }
+
+    @Override
+    public String toString() {
+        return this.queue.toString();
+    }
+
+    private DeleteMessageBatchResult deleteMessageBatch(final List<Message> messages) {
+        try {
+            final DeleteMessageBatchRequest request = this.factory.createDeleteMessageBatchRequest(this.queue, messages);
+            Log.info("Send delete request for %d message(s) to %s", messages.size(), this.queue);
+            return this.sqs.deleteMessageBatch(request);
+
+        } catch (final com.amazonaws.AmazonServiceException e) {
+            Log.severe(e, "Delete from %s failed", this.queue);
+
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/relution/jenkins/scmsqs/net/SQSChannelImpl.java
+++ b/src/main/java/io/relution/jenkins/scmsqs/net/SQSChannelImpl.java
@@ -38,6 +38,9 @@ public class SQSChannelImpl implements SQSChannel {
     private final SQSQueue   queue;
     private final SQSFactory factory;
 
+    /**
+     * Number of requests that were sent (for logging)
+     */
     private int              requestCount;
 
     public SQSChannelImpl(final AmazonSQS sqs, final SQSQueue queue, final SQSFactory factory) {
@@ -53,8 +56,7 @@ public class SQSChannelImpl implements SQSChannel {
     @Override
     public List<Message> getMessages() {
         try {
-            this.requestCount++;
-            Log.fine("Send receive message request #%d for %s", this.requestCount, this.queue);
+            this.logRequestCount();
 
             final ReceiveMessageRequest request = this.factory.createReceiveMessageRequest(this.queue);
             final ReceiveMessageResult result = this.sqs.receiveMessage(request);
@@ -97,6 +99,11 @@ public class SQSChannelImpl implements SQSChannel {
     @Override
     public String toString() {
         return this.queue.toString();
+    }
+
+    private void logRequestCount() {
+        this.requestCount++;
+        Log.fine("Send receive message request #%d for %s", this.requestCount, this.queue);
     }
 
     private DeleteMessageBatchResult deleteMessageBatch(final List<Message> messages) {

--- a/src/test/java/io/relution/jenkins/scmsqs/net/SQSQueueImplTest.java
+++ b/src/test/java/io/relution/jenkins/scmsqs/net/SQSQueueImplTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.relution.jenkins.scmsqs.net;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.BatchResultErrorEntry;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchResult;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchResultEntry;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.relution.jenkins.scmsqs.interfaces.SQSFactory;
+import io.relution.jenkins.scmsqs.interfaces.SQSQueue;
+
+
+public class SQSQueueImplTest {
+
+    @Mock
+    private SQSFactory                factory;
+
+    @Mock
+    private AmazonSQSAsync            sqs;
+
+    @Mock
+    private SQSQueue                  queue;
+
+    @Mock
+    private ReceiveMessageRequest     receiveRequest;
+
+    @Mock
+    private ReceiveMessageResult      receiveResult;
+
+    @Mock
+    private DeleteMessageBatchRequest deleteRequest;
+
+    @Mock
+    private DeleteMessageBatchResult  deleteResult;
+
+    private final List<Message>       messages = new ArrayList<>();
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+
+        Mockito.when(this.factory.createSQS(Matchers.any(SQSQueue.class))).thenReturn(this.sqs);
+        Mockito.when(this.factory.createSQSAsync(Matchers.any(SQSQueue.class))).thenReturn(this.sqs);
+        Mockito.when(this.factory.createReceiveMessageRequest(this.queue)).thenReturn(this.receiveRequest);
+        Mockito.when(this.factory.createDeleteMessageBatchRequest(this.queue, this.messages)).thenReturn(this.deleteRequest);
+
+        final Message message = new Message();
+        this.messages.add(message);
+
+        Mockito.when(this.sqs.receiveMessage(this.receiveRequest)).thenReturn(this.receiveResult);
+        Mockito.when(this.sqs.deleteMessageBatch(this.deleteRequest)).thenReturn(this.deleteResult);
+
+        Mockito.when(this.receiveResult.getMessages()).thenReturn(this.messages);
+
+        final List<DeleteMessageBatchResultEntry> result = Collections.emptyList();
+        final List<BatchResultErrorEntry> errors = Collections.emptyList();
+        Mockito.when(this.deleteResult.getSuccessful()).thenReturn(result);
+        Mockito.when(this.deleteResult.getFailed()).thenReturn(errors);
+    }
+
+    @Test
+    public void shouldReturnMessages() {
+        final SQSChannel channel = new SQSChannelImpl(this.sqs, this.queue, this.factory);
+
+        final List<Message> messages = channel.getMessages();
+
+        assertThat(messages).isSameAs(this.messages);
+    }
+
+    @Test
+    public void shouldDeleteMessages() {
+        final SQSChannel channel = new SQSChannelImpl(this.sqs, this.queue, this.factory);
+
+        channel.deleteMessages(this.messages);
+
+        Mockito.verify(this.factory).createDeleteMessageBatchRequest(this.queue, this.messages);
+        Mockito.verify(this.sqs).deleteMessageBatch(this.deleteRequest);
+    }
+}

--- a/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
+++ b/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
@@ -112,35 +112,31 @@ public class SQSQueueMonitorImplTest {
 
     @Test
     public void shouldStartAndStop() {
-        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+        assertThat(this.monitor.add(this.listener)).isTrue();
+        Mockito.verify(this.executor).execute(this.monitor);
+        assertThat(this.monitor.isShutDown()).isFalse();
 
-        assertThat(monitor.add(this.listener)).isTrue();
-        Mockito.verify(this.executor).execute(monitor);
-        assertThat(monitor.isShutDown()).isFalse();
-
-        assertThat(monitor.add(this.listener)).isFalse();
+        assertThat(this.monitor.add(this.listener)).isFalse();
         Mockito.verifyNoMoreInteractions(this.executor);
-        assertThat(monitor.isShutDown()).isFalse();
+        assertThat(this.monitor.isShutDown()).isFalse();
 
-        assertThat(monitor.remove(this.listener)).isFalse();
+        assertThat(this.monitor.remove(this.listener)).isFalse();
         Mockito.verifyNoMoreInteractions(this.executor);
-        assertThat(monitor.isShutDown()).isFalse();
+        assertThat(this.monitor.isShutDown()).isFalse();
 
-        assertThat(monitor.remove(this.listener)).isTrue();
+        assertThat(this.monitor.remove(this.listener)).isTrue();
         Mockito.verifyNoMoreInteractions(this.executor);
-        assertThat(monitor.isShutDown()).isTrue();
+        assertThat(this.monitor.isShutDown()).isTrue();
     }
 
     @Test
     public void shouldQueryQueue() {
-        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
-
-        assertThat(monitor.add(this.listener)).isTrue();
+        assertThat(this.monitor.add(this.listener)).isTrue();
         Mockito.verify(this.channel).getQueueUuid();
         Mockito.verify(this.listener).getQueueUuid();
-        Mockito.verify(this.executor).execute(monitor);
+        Mockito.verify(this.executor).execute(this.monitor);
 
-        monitor.run();
+        this.monitor.run();
 
         Mockito.verify(this.channel).getMessages();
 
@@ -150,7 +146,7 @@ public class SQSQueueMonitorImplTest {
         Mockito.verify(this.channel).deleteMessages(this.messages);
         Mockito.verifyNoMoreInteractions(this.channel);
 
-        Mockito.verify(this.executor, Mockito.times(2)).execute(monitor);
+        Mockito.verify(this.executor, Mockito.times(2)).execute(this.monitor);
     }
 
     @Test
@@ -158,36 +154,32 @@ public class SQSQueueMonitorImplTest {
         final List<Message> messages = Collections.emptyList();
         Mockito.when(this.channel.getMessages()).thenReturn(messages);
 
-        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
-
-        assertThat(monitor.add(this.listener)).isTrue();
+        assertThat(this.monitor.add(this.listener)).isTrue();
         Mockito.verify(this.channel).getQueueUuid();
         Mockito.verify(this.listener).getQueueUuid();
-        Mockito.verify(this.executor).execute(monitor);
+        Mockito.verify(this.executor).execute(this.monitor);
 
-        monitor.run();
+        this.monitor.run();
 
         Mockito.verify(this.channel).getMessages();
 
         Mockito.verifyNoMoreInteractions(this.listener);
         Mockito.verifyNoMoreInteractions(this.channel);
 
-        Mockito.verify(this.executor, Mockito.times(2)).execute(monitor);
+        Mockito.verify(this.executor, Mockito.times(2)).execute(this.monitor);
     }
 
     @Test
     public void shouldNotRunIfAlreadyShutDown() {
-        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
-
-        assertThat(monitor.add(this.listener)).isTrue();
+        assertThat(this.monitor.add(this.listener)).isTrue();
         Mockito.verify(this.channel).getQueueUuid();
         Mockito.verify(this.listener).getQueueUuid();
-        Mockito.verify(this.executor).execute(monitor);
+        Mockito.verify(this.executor).execute(this.monitor);
 
-        monitor.shutDown();
-        monitor.run();
+        this.monitor.shutDown();
+        this.monitor.run();
 
-        assertThat(monitor.isShutDown()).isTrue();
+        assertThat(this.monitor.isShutDown()).isTrue();
 
         Mockito.verifyNoMoreInteractions(this.channel);
         Mockito.verifyNoMoreInteractions(this.listener);

--- a/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
+++ b/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
@@ -97,17 +97,13 @@ public class SQSQueueMonitorImplTest {
         Mockito.when(this.listener.getQueueUuid()).thenReturn("a");
         Mockito.when(this.channel.getQueueUuid()).thenReturn("b");
 
-        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
-        Throwable thrown = null;
+        assertThatThrownBy(new ThrowingCallable() {
 
-        try {
-            monitor.add(null);
-        } catch (final Throwable t) {
-            thrown = t;
-        }
-
-        assertThat(thrown).isNotNull();
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+            @Override
+            public void call() throws Throwable {
+                SQSQueueMonitorImplTest.this.monitor.add(SQSQueueMonitorImplTest.this.listener);
+            }
+        }).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
+++ b/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2016 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.relution.jenkins.scmsqs.threading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.services.sqs.model.Message;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import io.relution.jenkins.scmsqs.interfaces.SQSQueueListener;
+import io.relution.jenkins.scmsqs.interfaces.SQSQueueMonitor;
+import io.relution.jenkins.scmsqs.net.SQSChannel;
+
+
+public class SQSQueueMonitorImplTest {
+
+    @Mock
+    private ExecutorService     executor;
+
+    @Mock
+    private SQSChannel          channel;
+
+    @Mock
+    private SQSQueueListener    listener;
+
+    private final List<Message> messages = new ArrayList<>();
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+
+        final Message message = new Message();
+        this.messages.add(message);
+
+        Mockito.when(this.channel.getMessages()).thenReturn(this.messages);
+
+        Mockito.when(this.listener.getQueueUuid()).thenReturn("a");
+        Mockito.when(this.channel.getQueueUuid()).thenReturn("a");
+    }
+
+    @Test
+    public void shouldThrowIfRegisterNullListener() {
+        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+        Throwable thrown = null;
+
+        try {
+            monitor.add(null);
+        } catch (final Throwable t) {
+            thrown = t;
+        }
+
+        assertThat(thrown).isNotNull();
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void shouldNotThrowIfUnregisterNullListener() {
+        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+        Throwable thrown = null;
+
+        try {
+            assertThat(monitor.remove(null)).isFalse();
+        } catch (final Throwable t) {
+            thrown = t;
+        }
+
+        assertThat(thrown).isNull();
+        assertThat(monitor.isShutDown()).isFalse();
+    }
+
+    @Test
+    public void shouldNotThrowIfUnregisterUnknown() {
+        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+        Throwable thrown = null;
+
+        try {
+            assertThat(monitor.remove(this.listener)).isFalse();
+        } catch (final Throwable t) {
+            thrown = t;
+        }
+
+        assertThat(thrown).isNull();
+        assertThat(monitor.isShutDown()).isFalse();
+    }
+
+    @Test
+    public void shouldThrowIfWrongQueue() {
+        Mockito.when(this.listener.getQueueUuid()).thenReturn("a");
+        Mockito.when(this.channel.getQueueUuid()).thenReturn("b");
+
+        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+        Throwable thrown = null;
+
+        try {
+            monitor.add(null);
+        } catch (final Throwable t) {
+            thrown = t;
+        }
+
+        assertThat(thrown).isNotNull();
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void shouldStartAndStop() {
+        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+
+        assertThat(monitor.add(this.listener)).isTrue();
+        Mockito.verify(this.executor).execute(monitor);
+        assertThat(monitor.isShutDown()).isFalse();
+
+        assertThat(monitor.add(this.listener)).isFalse();
+        Mockito.verifyNoMoreInteractions(this.executor);
+        assertThat(monitor.isShutDown()).isFalse();
+
+        assertThat(monitor.remove(this.listener)).isFalse();
+        Mockito.verifyNoMoreInteractions(this.executor);
+        assertThat(monitor.isShutDown()).isFalse();
+
+        assertThat(monitor.remove(this.listener)).isTrue();
+        Mockito.verifyNoMoreInteractions(this.executor);
+        assertThat(monitor.isShutDown()).isTrue();
+    }
+
+    @Test
+    public void shouldQueryQueue() {
+        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+
+        assertThat(monitor.add(this.listener)).isTrue();
+        Mockito.verify(this.channel).getQueueUuid();
+        Mockito.verify(this.listener).getQueueUuid();
+        Mockito.verify(this.executor).execute(monitor);
+
+        monitor.run();
+
+        Mockito.verify(this.channel).getMessages();
+
+        Mockito.verify(this.listener).handleMessages(this.messages);
+        Mockito.verifyNoMoreInteractions(this.listener);
+
+        Mockito.verify(this.channel).deleteMessages(this.messages);
+        Mockito.verifyNoMoreInteractions(this.channel);
+
+        Mockito.verify(this.executor, Mockito.times(2)).execute(monitor);
+    }
+
+    @Test
+    public void shouldNotSendDeleteRequestIfResultIsEmpty() {
+        final List<Message> messages = Collections.emptyList();
+        Mockito.when(this.channel.getMessages()).thenReturn(messages);
+
+        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+
+        assertThat(monitor.add(this.listener)).isTrue();
+        Mockito.verify(this.channel).getQueueUuid();
+        Mockito.verify(this.listener).getQueueUuid();
+        Mockito.verify(this.executor).execute(monitor);
+
+        monitor.run();
+
+        Mockito.verify(this.channel).getMessages();
+
+        Mockito.verifyNoMoreInteractions(this.listener);
+        Mockito.verifyNoMoreInteractions(this.channel);
+
+        Mockito.verify(this.executor, Mockito.times(2)).execute(monitor);
+    }
+
+    @Test
+    public void shouldNotRunIfAlreadyShutDown() {
+        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
+
+        assertThat(monitor.add(this.listener)).isTrue();
+        Mockito.verify(this.channel).getQueueUuid();
+        Mockito.verify(this.listener).getQueueUuid();
+        Mockito.verify(this.executor).execute(monitor);
+
+        monitor.shutDown();
+        monitor.run();
+
+        assertThat(monitor.isShutDown()).isTrue();
+
+        Mockito.verifyNoMoreInteractions(this.channel);
+        Mockito.verifyNoMoreInteractions(this.listener);
+
+        Mockito.verifyNoMoreInteractions(this.executor);
+    }
+}

--- a/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
+++ b/src/test/java/io/relution/jenkins/scmsqs/threading/SQSQueueMonitorImplTest.java
@@ -17,9 +17,11 @@
 package io.relution.jenkins.scmsqs.threading;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.amazonaws.services.sqs.model.Message;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -47,6 +49,8 @@ public class SQSQueueMonitorImplTest {
     @Mock
     private SQSQueueListener    listener;
 
+    private SQSQueueMonitor     monitor;
+
     private final List<Message> messages = new ArrayList<>();
 
     @Before
@@ -60,51 +64,32 @@ public class SQSQueueMonitorImplTest {
 
         Mockito.when(this.listener.getQueueUuid()).thenReturn("a");
         Mockito.when(this.channel.getQueueUuid()).thenReturn("a");
+
+        this.monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
     }
 
     @Test
     public void shouldThrowIfRegisterNullListener() {
-        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
-        Throwable thrown = null;
+        assertThatThrownBy(new ThrowingCallable() {
 
-        try {
-            monitor.add(null);
-        } catch (final Throwable t) {
-            thrown = t;
-        }
+            @Override
+            public void call() throws Throwable {
+                SQSQueueMonitorImplTest.this.monitor.add(null);
+            }
 
-        assertThat(thrown).isNotNull();
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+        }).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void shouldNotThrowIfUnregisterNullListener() {
-        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
-        Throwable thrown = null;
-
-        try {
-            assertThat(monitor.remove(null)).isFalse();
-        } catch (final Throwable t) {
-            thrown = t;
-        }
-
-        assertThat(thrown).isNull();
-        assertThat(monitor.isShutDown()).isFalse();
+        assertThat(this.monitor.remove(null)).isFalse();
+        assertThat(this.monitor.isShutDown()).isFalse();
     }
 
     @Test
     public void shouldNotThrowIfUnregisterUnknown() {
-        final SQSQueueMonitor monitor = new SQSQueueMonitorImpl(this.executor, this.channel);
-        Throwable thrown = null;
-
-        try {
-            assertThat(monitor.remove(this.listener)).isFalse();
-        } catch (final Throwable t) {
-            thrown = t;
-        }
-
-        assertThat(thrown).isNull();
-        assertThat(monitor.isShutDown()).isFalse();
+        assertThat(this.monitor.remove(this.listener)).isFalse();
+        assertThat(this.monitor.isShutDown()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
This moves network communication to its own class, to improve testability of the queue monitor and the network layer.